### PR TITLE
perf: adaptive pagination and leaner epoch/price fetching

### DIFF
--- a/sugar/chains.py
+++ b/sugar/chains.py
@@ -196,10 +196,51 @@ class CommonChain:
         # filter out paths with excluded tokens
         return list(filter(lambda p: len(set(map(lambda t: t[0], p)) & exclude_tokens_set) == 0, paths))
 
-    def get_pool_paginator(self, batch_size = 5) -> List[List[Tuple]]:
-        limit, upper_bound = self.settings.pool_page_size, self.settings.pools_count_upper_bound
+    def calculate_optimal_batch_size(self, pool_count: int) -> int:
+        """Per-batch pool page size aiming for ~pool_pagination_target_calls reads, clamped to [min, max]."""
+        target_calls = self.settings.pool_pagination_target_calls
+        min_size, max_size = self.settings.pool_pagination_min_size, self.settings.pool_pagination_max_size
+        return max(min_size, min(pool_count // target_calls, max_size))
+
+    def get_pool_paginator(self, batch_size: int = 5, pool_count: Optional[int] = None, use_optimal_sizing: bool = True) -> List[List[Tuple]]:
+        """Build (offset, limit) pagination batches. When pool_count is known, size pages adaptively
+        and bound the range to the live count (+10 buffer); otherwise fall back to static config."""
+        if pool_count is not None:
+            upper_bound = pool_count + 10
+            limit = self.calculate_optimal_batch_size(pool_count) if use_optimal_sizing else self.settings.pool_page_size
+        else:
+            upper_bound, limit = self.settings.pools_count_upper_bound, self.settings.pool_page_size
         return chunk(list(map(lambda x: (x, limit), list(range(0, upper_bound, limit)))), batch_size)
-    
+
+    def get_price_connectors(self) -> List[str]:
+        return list(dict.fromkeys(self.settings.connector_tokens_addrs + [self.settings.stable_token_addr]))
+
+    def get_price_request_tokens(self, tokens: List[Token]) -> List[Token]:
+        """Only native/listed/emerging tokens are worth pricing; dedup by address."""
+        return list({t.token_address: t for t in tokens if t.is_native or t.listed or t.emerging}.values())
+
+    def get_latest_epoch_price_tokens(self, epochs: List[Tuple], raw_pools: List[Tuple], tokens: List[Token]) -> List[Token]:
+        """Tokens whose prices the latest-epoch view actually needs: stable + native (for USD conversion),
+        each epoch pool's token0/token1/emissions token, and every fee/incentive reward token."""
+        tokens_by_address = {t.token_address: t for t in tokens}
+        needed = {self.settings.stable_token_addr}
+        native = next((t for t in tokens if t.is_native), None)
+        if native is not None: needed.add(native.token_address)
+        for pool in raw_pools:
+            needed.update([normalize_address(pool[7]), normalize_address(pool[10]), normalize_address(pool[20])])
+        for epoch in epochs:
+            needed.update(normalize_address(addr) for addr, _ in epoch[4])
+            needed.update(normalize_address(addr) for addr, _ in epoch[5])
+        return [t for addr, t in tokens_by_address.items()
+                if addr in needed and (t.is_native or t.listed or t.emerging)]
+
+    def get_price_chunk_size(self, tokens: List[Token]) -> int:
+        return max(3, min((len(tokens) + 59) // 60, 20))
+
+    def get_price_token_chunks(self, tokens: List[Token]) -> List[List[Token]]:
+        tokens = self.get_price_request_tokens(tokens)
+        return list(chunk(tokens, self.get_price_chunk_size(tokens)))
+
     def prepare_price_batcher(self, tokens: List[Token], batch: RequestBatcher):
         batches = chunk(tokens, self.settings.price_batch_size)
         for b in batches:
@@ -246,13 +287,19 @@ class AsyncChain(CommonChain):
         await self.web3.provider.disconnect()
         return None
 
-    async def apaginate(self, f: Callable):
+    async def apaginate(self, f: Callable, pool_count: Optional[int] = None):
         async def process_batch(batch: List[Tuple]):
             async with self.web3.batch_requests() as batcher:
                 for offset, limit in batch: batcher.add(f(limit, offset))
-                return sum(await batcher.async_execute(), [])
-        return sum(await asyncio.gather(*[process_batch(batch) for batch in self.get_pool_paginator()]), [])
-    
+                results = await batcher.async_execute()
+                return sum([r for r in results if not isinstance(r, Exception)], [])
+        return sum(await asyncio.gather(*[process_batch(batch) for batch in self.get_pool_paginator(pool_count=pool_count)]), [])
+
+    @require_async_context
+    async def get_pool_count(self) -> int:
+        """Total pool count from the sugar contract; drives adaptive pagination sizing."""
+        return await self.sugar.functions.count().call()
+
     @require_async_context
     async def get_bridge_fee(self, domain: int) -> int:
         contract = self.web3.eth.contract(address=self.settings.bridge_contract_addr, abi=get_abi("bridge_get_fee"))
@@ -321,8 +368,9 @@ class AsyncChain(CommonChain):
     @require_async_context
     @alru_cache(maxsize=None)
     async def get_all_tokens(self, listed_only: bool = False) -> List[Token]:
+        pool_count = await self.get_pool_count()
         def get_tokens(limit, offset): return self.sugar.functions.tokens(limit, offset, ADDRESS_ZERO, [])
-        return self.prepare_tokens(await self.apaginate(get_tokens), listed_only)
+        return self.prepare_tokens(await self.apaginate(get_tokens, pool_count=pool_count), listed_only)
     
     @require_async_context
     async def get_token(self, ref) -> Optional[Token]:
@@ -350,16 +398,17 @@ class AsyncChain(CommonChain):
     async def get_bridge_token(self) -> Token: return self._get_bridge_token(await self.get_all_tokens())
 
     async def _get_prices(self, tokens: Tuple[Token], max_retries: int = 3) -> List[int]:
-        """Batched price oracle reads. Retries any failed chunks; raises with context if any remain after retries."""
-        chunks = list(chunk(list(tokens), self.settings.price_batch_size))
+        """Batched price oracle reads. Only native/listed/emerging tokens are requested (others resolve
+        to 0); rates are mapped back onto the full input order. Retries failed chunks; raises if any remain."""
+        chunks = self.get_price_token_chunks(list(tokens))
         async def _exec(cs):
             async with self.web3.batch_requests() as b:
                 for c in cs:
                     b.add(self.prices.functions.getManyRatesToEthWithCustomConnectors(
                         [t.wrapped_token_address or t.token_address for t in c],
-                        False, self.settings.connector_tokens_addrs, 10))
+                        False, self.get_price_connectors(), self.settings.price_threshold_filter))
                 return await b.async_execute()
-        results = await _exec(chunks)
+        results = await _exec(chunks) if chunks else []
         for _ in range(max_retries):
             failed = [i for i, r in enumerate(results) if not isinstance(r, list)]
             if not failed: break
@@ -369,7 +418,10 @@ class AsyncChain(CommonChain):
         if bad:
             i, e = bad[0]
             raise RuntimeError(f"price oracle batch failed: {len(bad)}/{len(results)} chunks unresolved after {max_retries} retries (chunk #{i}: {type(e).__name__}: {e})")
-        return sum(results, [])
+        rates_by_address = {}
+        for c, r in zip(chunks, results):
+            for t, rate in zip(c, r): rates_by_address[t.token_address] = rate
+        return [rates_by_address.get(t.token_address, 0) for t in tokens]
 
     @require_async_context
     async def get_prices(self, tokens: List[Token]) -> List[Price]:
@@ -378,9 +430,21 @@ class AsyncChain(CommonChain):
 
     @alru_cache(maxsize=None)
     async def get_raw_pools(self, for_swaps: bool):
+        pool_count = await self.get_pool_count()
         def get_all(limit, offset): return self.sugar.functions.all(limit, offset, 0)
-        return await self.apaginate(self.sugar.functions.forSwaps if for_swaps else get_all)
-    
+        return await self.apaginate(self.sugar.functions.forSwaps if for_swaps else get_all, pool_count=pool_count)
+
+    @require_async_context
+    async def get_raw_pools_by_addresses(self, addresses: Tuple[str, ...]) -> List[Tuple]:
+        """Fetch specific pools by LP address concurrently, skipping any that fail to resolve."""
+        semaphore = asyncio.Semaphore(10)
+        async def fetch_pool(address: str):
+            async with semaphore:
+                try: return await self.sugar.functions.byAddress(normalize_address(address)).call()
+                except Exception: return None
+        results = await asyncio.gather(*[fetch_pool(a) for a in addresses])
+        return [p for p in results if p is not None]
+
     @require_async_context
     async def get_pools(self, for_swaps: bool = False) -> List[LiquidityPool]:
         pools = await self.get_raw_pools(for_swaps)
@@ -400,9 +464,15 @@ class AsyncChain(CommonChain):
     @require_async_context
     @alru_cache(maxsize=None)
     async def get_latest_pool_epochs(self) -> List[LiquidityPoolEpoch]:
-        tokens, pools = await self.get_all_tokens(listed_only=False), await self.get_pools()
-        prices = await self.get_prices(tokens)
-        return self.prepare_pool_epochs(await self.apaginate(self.sugar_rewards.functions.epochsLatest), pools, tokens, prices)
+        pool_count = await self.get_pool_count()
+        raw_epochs = await self.apaginate(self.sugar_rewards.functions.epochsLatest, pool_count=pool_count)
+        if not raw_epochs: return []
+        tokens = await self.get_all_tokens(listed_only=False)
+        epoch_lp_addresses = {normalize_address(epoch[1]) for epoch in raw_epochs}
+        raw_pools = [p for p in await self.get_raw_pools(False) if normalize_address(p[0]) in epoch_lp_addresses]
+        prices = await self.get_prices(self.get_latest_epoch_price_tokens(raw_epochs, raw_pools, tokens))
+        pools = self.prepare_pools(raw_pools, tokens, prices)
+        return self.prepare_pool_epochs(raw_epochs, pools, tokens, prices)
     
     @require_async_context
     async def get_pools_for_swaps(self) -> List[LiquidityPoolForSwap]: return await self.get_pools(for_swaps=True)
@@ -760,15 +830,15 @@ class Chain(CommonChain):
         self._in_context = False
         return None
     
-    def paginate(self, f: Callable):
-        results, batches = [], self.get_pool_paginator()
+    def paginate(self, f: Callable, pool_count: Optional[int] = None):
+        results, batches = [], self.get_pool_paginator(pool_count=pool_count)
 
         def process_batch(batch: List[Tuple]):
             with self.web3.batch_requests() as batcher:
                 for offset, limit in batch: batcher.add(f(limit, offset))
-                return sum(batcher.execute(), [])
+                return sum([r for r in batcher.execute() if not isinstance(r, Exception)], [])
 
-        
+
         with ThreadPoolExecutor(max_workers=self.settings.threading_max_workers) as executor:
             future_to_batch = {
                 executor.submit(process_batch, batch): batch
@@ -781,6 +851,11 @@ class Chain(CommonChain):
                     continue
 
         return results
+
+    @require_context
+    def get_pool_count(self) -> int:
+        """Total pool count from the sugar contract; drives adaptive pagination sizing."""
+        return self.sugar.functions.count().call()
 
     @require_context
     def get_bridge_fee(self, domain: int) -> int:
@@ -854,8 +929,9 @@ class Chain(CommonChain):
     @require_context
     @lru_cache(maxsize=None)
     def get_all_tokens(self, listed_only: bool = False) -> List[Token]:
+        pool_count = self.get_pool_count()
         def get_tokens(limit, offset): return self.sugar.functions.tokens(limit, offset, ADDRESS_ZERO, [])
-        return self.prepare_tokens(self.paginate(get_tokens), listed_only)
+        return self.prepare_tokens(self.paginate(get_tokens, pool_count=pool_count), listed_only)
 
     @require_context
     def get_token(self, ref) -> Optional[Token]:
@@ -889,16 +965,17 @@ class Chain(CommonChain):
     def get_bridge_token(self) -> Token: return self._get_bridge_token(self.get_all_tokens())
 
     def _get_prices(self, tokens: Tuple[Token], max_retries: int = 3) -> List[int]:
-        """Batched price oracle reads. Retries any failed chunks; raises with context if any remain after retries."""
-        chunks = list(chunk(list(tokens), self.settings.price_batch_size))
+        """Batched price oracle reads. Only native/listed/emerging tokens are requested (others resolve
+        to 0); rates are mapped back onto the full input order. Retries failed chunks; raises if any remain."""
+        chunks = self.get_price_token_chunks(list(tokens))
         def _exec(cs):
             with self.web3.batch_requests() as b:
                 for c in cs:
                     b.add(self.prices.functions.getManyRatesToEthWithCustomConnectors(
                         [t.wrapped_token_address or t.token_address for t in c],
-                        False, self.settings.connector_tokens_addrs, 10))
+                        False, self.get_price_connectors(), self.settings.price_threshold_filter))
                 return b.execute()
-        results = _exec(chunks)
+        results = _exec(chunks) if chunks else []
         for _ in range(max_retries):
             failed = [i for i, r in enumerate(results) if not isinstance(r, list)]
             if not failed: break
@@ -908,7 +985,10 @@ class Chain(CommonChain):
         if bad:
             i, e = bad[0]
             raise RuntimeError(f"price oracle batch failed: {len(bad)}/{len(results)} chunks unresolved after {max_retries} retries (chunk #{i}: {type(e).__name__}: {e})")
-        return sum(results, [])
+        rates_by_address = {}
+        for c, r in zip(chunks, results):
+            for t, rate in zip(c, r): rates_by_address[t.token_address] = rate
+        return [rates_by_address.get(t.token_address, 0) for t in tokens]
 
     @require_context
     def get_prices(self, tokens: List[Token]) -> List[Price]:
@@ -917,8 +997,18 @@ class Chain(CommonChain):
     
     @lru_cache(maxsize=None)
     def get_raw_pools(self, for_swaps: bool):
+        pool_count = self.get_pool_count()
         def get_all(limit, offset): return self.sugar.functions.all(limit, offset, 0)
-        return self.paginate(self.sugar.functions.forSwaps if for_swaps else get_all)
+        return self.paginate(self.sugar.functions.forSwaps if for_swaps else get_all, pool_count=pool_count)
+
+    @require_context
+    def get_raw_pools_by_addresses(self, addresses: Tuple[str, ...]) -> List[Tuple]:
+        """Fetch specific pools by LP address concurrently, skipping any that fail to resolve."""
+        def fetch_pool(address: str):
+            try: return self.sugar.functions.byAddress(normalize_address(address)).call()
+            except Exception: return None
+        with ThreadPoolExecutor(max_workers=min(10, self.settings.threading_max_workers)) as executor:
+            return [p for p in executor.map(fetch_pool, addresses) if p is not None]
 
     @require_context
     def get_pools(self, for_swaps: bool = False) -> List[LiquidityPool]:
@@ -942,9 +1032,15 @@ class Chain(CommonChain):
     @require_context
     @lru_cache(maxsize=None)
     def get_latest_pool_epochs(self) -> List[LiquidityPoolEpoch]:
-        tokens, pools = self.get_all_tokens(listed_only=False), self.get_pools()
-        prices = self.get_prices(tokens)
-        return self.prepare_pool_epochs(self.paginate(self.sugar_rewards.functions.epochsLatest), pools, tokens, prices)
+        pool_count = self.get_pool_count()
+        raw_epochs = self.paginate(self.sugar_rewards.functions.epochsLatest, pool_count=pool_count)
+        if not raw_epochs: return []
+        tokens = self.get_all_tokens(listed_only=False)
+        epoch_lp_addresses = {normalize_address(epoch[1]) for epoch in raw_epochs}
+        raw_pools = [p for p in self.get_raw_pools(False) if normalize_address(p[0]) in epoch_lp_addresses]
+        prices = self.get_prices(self.get_latest_epoch_price_tokens(raw_epochs, raw_pools, tokens))
+        pools = self.prepare_pools(raw_pools, tokens, prices)
+        return self.prepare_pool_epochs(raw_epochs, pools, tokens, prices)
 
     @require_context
     def _get_quotes_for_paths(self, from_token: Token, to_token: Token, amount_in: int, pools: List[LiquidityPoolForSwap], paths: List[List[Tuple]]) -> List[Optional[Quote]]:

--- a/sugar/config.py
+++ b/sugar/config.py
@@ -18,6 +18,10 @@ base_default_settings = {
   "pool_page_size": int(os.getenv("SUGAR_POOL_PAGE_SIZE","500")),
   # XX: dealing with Schrödinger's paginator this is likely to be ignored in the future with new sugar helpers
   "pools_count_upper_bound": 2500,
+  # adaptive pool pagination: pick a per-batch size aiming for ~target_calls RPC reads, clamped to [min, max]
+  "pool_pagination_target_calls": int(os.getenv("SUGAR_POOL_PAGINATION_TARGET_CALLS","90")),
+  "pool_pagination_min_size": int(os.getenv("SUGAR_POOL_PAGINATION_MIN_SIZE","10")),
+  "pool_pagination_max_size": int(os.getenv("SUGAR_POOL_PAGINATION_MAX_SIZE","300")),
   "native_token_symbol": "ETH",
   "native_token_decimals": 18,
   "swap_slippage": 0.01,
@@ -63,6 +67,9 @@ class ChainSettings:
     pagination_limit: int
     pools_count_upper_bound: int
     pool_page_size: int
+    pool_pagination_target_calls: int
+    pool_pagination_min_size: int
+    pool_pagination_max_size: int
     native_token_symbol: str
     native_token_decimals: int
     # how often to check for new prices
@@ -89,7 +96,8 @@ def validate_settings(settings: ChainSettings) -> ChainSettings:
     # TODO: this should actually validate stuff, duh
     floats = ["swap_slippage"]
     ints = ["price_batch_size", "price_threshold_filter", "pagination_limit", "pool_page_size", "native_token_decimals",
-            "pricing_cache_timeout_seconds", "pools_count_upper_bound", "threading_max_workers"]
+            "pricing_cache_timeout_seconds", "pools_count_upper_bound", "threading_max_workers",
+            "pool_pagination_target_calls", "pool_pagination_min_size", "pool_pagination_max_size"]
     for k in floats: setattr(settings, k, float(getattr(settings, k)))
     for k in ints: setattr(settings, k, int(getattr(settings, k)))
     return settings

--- a/sugar/token.py
+++ b/sugar/token.py
@@ -16,6 +16,7 @@ class Token:
     symbol: str
     decimals: int
     listed: bool
+    emerging: bool = False
     wrapped_token_address: str = None
 
     def __eq__(self, other):
@@ -39,7 +40,7 @@ class Token:
 
     @classmethod
     def from_tuple(cls, t: Tuple, chain_id: str, chain_name: str) -> "Token":
-        (token_address, symbol, decimals, _, listed, _emerging) = t
+        (token_address, symbol, decimals, _, listed, emerging) = t
         return Token(
             chain_id=chain_id,
             chain_name=chain_name,
@@ -47,4 +48,5 @@ class Token:
             symbol=symbol,
             decimals=decimals,
             listed=listed,
+            emerging=emerging,
         )

--- a/tests/test_adaptive_sizing.py
+++ b/tests/test_adaptive_sizing.py
@@ -1,0 +1,59 @@
+"""Unit tests for adaptive pool pagination sizing (no network)."""
+from sugar.config import make_base_chain_settings
+from sugar.chains import CommonChain
+
+
+def _chain():
+    return CommonChain(make_base_chain_settings())
+
+
+def test_optimal_batch_size_small_chain_clamps_to_min():
+    # 100 // 90 = 1, clamped up to min_size (10)
+    assert _chain().calculate_optimal_batch_size(100) == 10
+
+
+def test_optimal_batch_size_medium_chain():
+    # 2500 // 90 = 27
+    optimal = _chain().calculate_optimal_batch_size(2500)
+    assert optimal == 27
+    assert 10 <= optimal <= 300
+
+
+def test_optimal_batch_size_large_chain():
+    # 9000 // 90 = 100
+    assert _chain().calculate_optimal_batch_size(9000) == 100
+
+
+def test_optimal_batch_size_clamps_to_max():
+    # 30000 // 90 = 333, clamped down to max_size (300)
+    assert _chain().calculate_optimal_batch_size(30000) == 300
+
+
+def test_optimal_batch_size_targets_about_90_calls():
+    optimal = _chain().calculate_optimal_batch_size(8100)
+    assert 80 <= 8100 / optimal <= 100
+
+
+def test_paginator_uses_optimal_sizing_when_pool_count_known():
+    batches = list(_chain().get_pool_paginator(batch_size=1, pool_count=2700, use_optimal_sizing=True))
+    _, first_limit = batches[0][0]
+    assert first_limit == 30  # 2700 // 90
+
+
+def test_paginator_backwards_compatible_when_optimal_disabled():
+    batches = list(_chain().get_pool_paginator(batch_size=1, pool_count=2700, use_optimal_sizing=False))
+    _, first_limit = batches[0][0]
+    assert first_limit == 500  # pool_page_size
+
+
+def test_paginator_without_pool_count_uses_defaults():
+    batches = list(_chain().get_pool_paginator(batch_size=1, pool_count=None, use_optimal_sizing=True))
+    _, first_limit = batches[0][0]
+    assert first_limit == 500  # pool_page_size
+
+
+def test_optimal_sizing_reduces_page_size_for_large_chains():
+    old = list(_chain().get_pool_paginator(batch_size=1, pool_count=9000, use_optimal_sizing=False))[0][0][1]
+    new = list(_chain().get_pool_paginator(batch_size=1, pool_count=9000, use_optimal_sizing=True))[0][0][1]
+    assert new < old
+    assert new == 100

--- a/tests/test_epochs.py
+++ b/tests/test_epochs.py
@@ -1,0 +1,91 @@
+"""Network tests for get_latest_pool_epochs (async + sync), exercising the
+epoch/price-fetching optimization end to end on Base."""
+import asyncio
+
+import pytest
+
+from sugar import AsyncBaseChain, BaseChain
+from sugar.pool import LiquidityPool, LiquidityPoolEpoch
+from sugar.token import Token
+
+pytestmark = pytest.mark.network
+
+
+@pytest.fixture(scope="module")
+def latest_pool_epochs():
+    async def run():
+        async with AsyncBaseChain() as chain:
+            return await chain.get_latest_pool_epochs()
+    return asyncio.run(run())
+
+
+@pytest.fixture(scope="module")
+def sync_latest_pool_epochs():
+    with BaseChain() as chain:
+        return chain.get_latest_pool_epochs()
+
+
+def test_returns_list_of_epochs(latest_pool_epochs):
+    epochs = latest_pool_epochs
+    assert isinstance(epochs, list)
+    assert len(epochs) > 0
+    assert all(isinstance(e, LiquidityPoolEpoch) for e in epochs)
+
+
+def test_epoch_data_structure(latest_pool_epochs):
+    epochs = latest_pool_epochs
+    # Base has many pools with epochs; guards against a pagination regression.
+    assert len(epochs) > 600, f"expected many epochs (>600), got {len(epochs)}"
+
+    e = epochs[0]
+    assert isinstance(e.ts, int) and e.ts > 0
+    assert isinstance(e.lp, str) and e.lp.startswith("0x")
+    assert isinstance(e.votes, int) and e.votes >= 0
+    assert isinstance(e.emissions, int) and e.emissions >= 0
+    assert isinstance(e.incentives, list)
+    assert isinstance(e.fees, list)
+
+
+def test_all_epochs_have_valid_pools(latest_pool_epochs):
+    # The optimization wires raw epoch -> filtered raw pool -> prepared pool; if the
+    # plumbing breaks, pools come back None. Assert every epoch resolved a pool.
+    epochs = latest_pool_epochs
+    without = [e for e in epochs if e.pool is None]
+    assert not without, f"{len(without)}/{len(epochs)} epochs missing pools, e.g. {[e.lp for e in without[:5]]}"
+    for e in epochs:
+        assert isinstance(e.pool, LiquidityPool)
+        assert isinstance(e.pool.token0, Token)
+        assert isinstance(e.pool.token1, Token)
+
+
+def test_total_value_is_substantial(latest_pool_epochs):
+    # Live-chain data drifts; keep this low enough to be stable but high enough to
+    # catch a pricing/pagination regression that zeroes everything out.
+    total = sum(e.total_fees + e.total_incentives for e in latest_pool_epochs)
+    assert total > 100_000, f"expected total fees + incentives > $100k, got ${total:,.2f}"
+
+
+def test_sync_returns_list_of_epochs(sync_latest_pool_epochs):
+    epochs = sync_latest_pool_epochs
+    assert isinstance(epochs, list)
+    assert len(epochs) > 0
+    assert all(isinstance(e, LiquidityPoolEpoch) for e in epochs)
+
+
+def test_sync_matches_async_count(latest_pool_epochs, sync_latest_pool_epochs):
+    # Same chain, same read path — counts should agree.
+    assert len(sync_latest_pool_epochs) == len(latest_pool_epochs)
+
+
+def test_requires_async_context():
+    async def run():
+        chain = AsyncBaseChain()
+        with pytest.raises(RuntimeError, match="async with"):
+            await chain.get_latest_pool_epochs()
+    asyncio.run(run())
+
+
+def test_sync_requires_context():
+    chain = BaseChain()
+    with pytest.raises(RuntimeError, match="async with"):
+        chain.get_latest_pool_epochs()

--- a/tests/test_prices.py
+++ b/tests/test_prices.py
@@ -1,0 +1,87 @@
+"""Network tests for get_prices (async + sync), covering the token-filtering
+price path and result alignment on Base."""
+import asyncio
+
+import pytest
+
+from sugar import AsyncBaseChain, BaseChain
+from sugar.price import Price
+
+pytestmark = pytest.mark.network
+
+
+@pytest.fixture(scope="module")
+def async_tokens_and_prices():
+    async def run():
+        async with AsyncBaseChain() as chain:
+            tokens = await chain.get_all_tokens()
+            return tokens, await chain.get_prices(tokens)
+    return asyncio.run(run())
+
+
+@pytest.fixture(scope="module")
+def sync_tokens_and_prices():
+    with BaseChain() as chain:
+        tokens = chain.get_all_tokens()
+        return tokens, chain.get_prices(tokens)
+
+
+def test_prices_align_with_tokens(async_tokens_and_prices):
+    tokens, prices = async_tokens_and_prices
+    assert isinstance(prices, list)
+    assert len(prices) == len(tokens), "one price per input token, in order"
+    assert len(tokens) > 40, "should exceed a single price chunk"
+    for p in prices:
+        assert isinstance(p, Price)
+        assert p.price >= 0
+
+
+def test_native_token_priced(async_tokens_and_prices):
+    tokens, prices = async_tokens_and_prices
+    assert tokens[0].symbol == "ETH"
+    assert 100 < prices[0].price < 100_000
+
+
+def test_stable_token_near_one(async_tokens_and_prices):
+    tokens, prices = async_tokens_and_prices
+    idx = next((i for i, t in enumerate(tokens) if t.symbol == "USDC"), None)
+    assert idx is not None
+    assert 0.95 <= prices[idx].price <= 1.05
+
+
+def test_prices_cached_within_ttl(async_tokens_and_prices):
+    tokens, _ = async_tokens_and_prices
+
+    async def run():
+        async with AsyncBaseChain() as chain:
+            first = await chain.get_prices(tokens)
+            second = await chain.get_prices(tokens)
+            return first, second
+
+    first, second = asyncio.run(run())
+    assert len(first) == len(second)
+    for a, b in zip(first, second):
+        assert a.token.token_address == b.token.token_address
+        assert a.price == b.price
+
+
+def test_sync_prices_align_with_tokens(sync_tokens_and_prices):
+    tokens, prices = sync_tokens_and_prices
+    assert len(prices) == len(tokens)
+    assert all(isinstance(p, Price) and p.price >= 0 for p in prices)
+    assert tokens[0].symbol == "ETH"
+    assert prices[0].price > 100
+
+
+def test_requires_async_context():
+    async def run():
+        chain = AsyncBaseChain()
+        with pytest.raises(RuntimeError, match="async with"):
+            await chain.get_prices([])
+    asyncio.run(run())
+
+
+def test_sync_requires_context():
+    chain = BaseChain()
+    with pytest.raises(RuntimeError, match="async with"):
+        chain.get_prices([])

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -13,3 +13,17 @@ def test_token_equality():
     assert velo == velo, "VELO and VELO should be equal"
     assert velo != velo_poser, "VELO and VELO poser should not be equal"
     assert velo != eth, "VELO and ETH should not be equal"
+
+
+def test_token_from_tuple_captures_emerging():
+    # Sugar's token tuple: (address, symbol, decimals, account_balance, listed, emerging)
+    addr = '0x9560e827aF36c94D2Ac33a39bCE1Fe78631088Db'
+    listed = Token.from_tuple((addr, 'VELO', 18, 0, True, False), chain_id="10", chain_name="OP")
+    emerging = Token.from_tuple((addr, 'NEW', 18, 0, False, True), chain_id="10", chain_name="OP")
+    assert listed.emerging is False
+    assert emerging.emerging is True
+
+
+def test_token_emerging_defaults_false():
+    t = Token(chain_id="10", chain_name="OP", token_address='0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85', symbol='USDC', decimals=6, listed=True)
+    assert t.emerging is False


### PR DESCRIPTION
Port read-path optimizations from the agile-sloth branch (rebuilt by hand onto the post-nbdev tree, since that branch predates the rewrite):

- adaptive pool pagination sized from the live pool count (~90 target reads, clamped 10-300) instead of a fixed 500
- get_latest_pool_epochs prices only the tokens its epochs reference and prepares only epoch pools, instead of pricing/preparing everything
- _get_prices filters to native/listed/emerging tokens, sizes chunks dynamically, includes the stable token as a connector, and maps results back onto the full input order (keeps main's batched retry/raise)
- add get_raw_pools_by_addresses and capture Token.emerging from the tuple